### PR TITLE
Now retrieving photos url (instagram) and cover url (facebook)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ Params have always the following properties available:
 * `maxID`: String, Optional. Fetch the posts from this ID.
 * `onlyWithLocation`: Boolean, Optional. Fetch only posts with location. Doesn't used if a custom parser function is provided.
 
+## Facebook-specific Parameters
+
+* `withCover`: Boolean, Optional. Include the cover photo (when available) for each location.
+
 ## Code sample:
 
 ```js
@@ -103,6 +107,7 @@ Promise.all([
                     "zip": "40213" // Zip (if available)
                 }
             }
+            "cover": "https://..." // Cover photo (if withCover = true)
         },
         // Other records
     ]
@@ -129,7 +134,8 @@ Promise.all([
                     "street": "Place de l\'Hôtel de Ville", // Street (if available)
                     "zip": "30100" // Zip (if available)
                 }
-            }
+            },
+            "cover": "https://..." // Cover photo (if withCover = true)
         },
         // Other records
     ]

--- a/services/facebook.js
+++ b/services/facebook.js
@@ -169,6 +169,7 @@ function constructRequest(uri, params, withCover) {
  * Request and paginate the results of a Facebook Endpoint
  * @param {*} uri Facebook Endpoint
  * @param {*} qs Query String (request parameters)
+ * @param {*} withCover Include the cover photo URL (if available)
  * @param {*} dest Destination. Used for streaming results (can be a response, a file or any output)
  * @param {*} parsingFunc A function to apply to each result
  * @param {*} maxItems Maximum number of items to retrieve
@@ -251,6 +252,7 @@ function paginateResults(uri, qs = {}, withCover, dest, parsingFunc, maxItems) {
  * @param {Object} params - Request Query String
  * @param {string} params.token - Facebook User Token
  * @param {string} [params.batchSize] - Items per batch. Optionnal
+ * @param {boolean} [params.withCover] - Include the cover photo URL. Optionnal
  * @param {integer} [params.maxItems] - Maximum number of items to retrieve. Optionnal
  * @param {Function} [params.parser] - Function to apply to each item. Optionnal
  * @param {*} dest An optionnal output destination
@@ -277,6 +279,7 @@ function getEvents(params = {}, dest) {
  * @param {Object} params - Request Query String
  * @param {string} params.token - Facebook User Token
  * @param {string} [params.batchSize] - Items per batch. Optionnal
+ * @param {boolean} [params.withCover] - Include the cover photo URL. Optionnal
  * @param {integer} [params.maxItems] - Maximum number of items to retrieve. Optionnal
  * @param {Function} [params.parser] - Function to apply to each item. Optionnal
  * @param {*} dest An optionnal output destination

--- a/services/facebook.js
+++ b/services/facebook.js
@@ -56,6 +56,116 @@ function getTestUserToken(appID, appToken, testUserID) {
 
 /** *************************************** REQUEST UTILS *************************************** */
 /**
+ * Parse a Facebook response
+ * If `withCover` is specified, it merges the cover source url into the locations object
+ * @param {*} response The Facebook Response
+ * @param {*} withCover True if this is a batch requests including Covers
+ */
+function parseFacebookResponse(response, withCover) {
+  const responseJSON = JSON.parse(response)
+
+  // No cover to merge, just return the parsed reponse
+  if (!withCover) {
+    return responseJSON
+  }
+
+  let places
+  let covers
+  try {
+    // Try to parse the places and covers
+    places = JSON.parse(responseJSON[0].body)
+    covers = JSON.parse(responseJSON[1].body)
+  } catch (e) {
+    // Something went wrong
+  }
+
+  // No places to handle
+  if (!places) {
+    return []
+  }
+  // If the places request returned an error, stop it there
+  if (places.error) {
+    throw places.error
+  }
+  // No covers, just return the places
+  if (!covers) {
+    return places
+  }
+  // If the covers request returned an error, log it but continue
+  if (covers.error) {
+    console.error('[Facebook Covers]', covers.error.message)
+  }
+
+  // Merge and return the covers in the places
+  return {
+    paging: places.paging,
+    data: places.data.map((place) => {
+      const placeID = place.place.id
+      const cover = (covers[placeID] && covers[placeID].cover && covers[placeID].cover.source)
+      return Object.assign(place, { cover: cover || null })
+    })
+  }
+}
+
+/**
+ * Constructs a relative URL with parameters for batch requests
+ * @param {*} uri The Facebook Endpoint
+ * @param {*} params The parameters
+ */
+function constructRelativeURI(uri, params) {
+  // Browses the parameters
+  return Object.keys(params).reduce((acc, param) => {
+    if (!params[param]) {
+      return acc
+    }
+
+    // Concat the param to the uri
+    return `${acc}${acc === uri ? '?' : '&'}${param}=${params[param]}`
+  }, uri)
+}
+
+/**
+ * Constructs the Facebook request.
+ * If `withCover` is specified, it constructs a batch request.
+ * @param {*} uri The Facebook endpoint
+ * @param {*} params The parameters
+ * @param {*} withCover True if covers url should be included
+ */
+function constructRequest(uri, params, withCover) {
+  if (!withCover) {
+    // No cover to fetch, just return a simple GET object
+    return {
+      uri: `${facebookHost}${facebookAPIVersion}${uri}`,
+      qs: params
+    }
+  }
+
+  // Else we need to construct a Facebook Batch Request
+  // See https://developers.facebook.com/docs/graph-api/making-multiple-requests#simple
+  return {
+    uri: facebookHost,
+    method: 'POST',
+    form: {
+      access_token: params.access_token,
+      include_headers: false, // We don't want to include the headers for a smaller response
+      batch: JSON.stringify([{
+        method: 'GET',
+        name: 'locations',
+        relative_url: constructRelativeURI(uri, params),
+        // We need to set it to false to get theses results
+        // See https://developers.facebook.com/docs/graph-api/making-multiple-requests#operations
+        omit_response_on_success: false
+      }, {
+        method: 'GET',
+        name: 'covers',
+        // We use the results of the previous request to get the cover URL for each location page
+        relative_url: '?ids={result=locations:$.data.*.place.id}&fields=cover{source}'
+      }])
+    }
+  }
+}
+
+/**
  * Request and paginate the results of a Facebook Endpoint
  * @param {*} uri Facebook Endpoint
  * @param {*} qs Query String (request parameters)
@@ -63,39 +173,45 @@ function getTestUserToken(appID, appToken, testUserID) {
  * @param {*} parsingFunc A function to apply to each result
  * @param {*} maxItems Maximum number of items to retrieve
  */
-function paginateResults(uri, qs = {}, dest, parsingFunc, maxItems) {
-  const options = { uri, qs } // Construction of the request
+function paginateResults(uri, qs = {}, withCover, dest, parsingFunc, maxItems) {
   let data = [] // Will contain all results
   let count = 0 // Count the number of results
+  const options = qs
 
   // If `maxItems` is specified but not `limit` (corresponding to batchSize),
   // assign `maxItems to `limit`
   // It will be useful later when determining how many items to retrieve to satisfy `maxItems`
-  if (!options.qs.limit && maxItems) {
-    options.qs.limit = maxItems
+  if (!qs.limit && maxItems) {
+    options.limit = maxItems
   }
 
   // Each call to this function will paginate to the next results
   return (function paginate(next) {
     // Assign the next cursor to the request query string
-    options.qs.after = next
+    if (next) {
+      options.after = next
+    }
 
     // Determine how many items we should retrieve to satisfy the `maxItems` condition.
     // If the current limit is greater than the number of items to get, compute the new limit
     // to only get the necessary items.
-    if (maxItems && (count + options.qs.limit > maxItems)) {
-      options.qs.limit = maxItems - count
+    if (maxItems && (count + options.limit > maxItems)) {
+      options.limit = maxItems - count
     }
 
+    // Construction of the request
+    const req = constructRequest(uri, options, withCover)
+
     // Do the request to the Facebook Endpoint
-    return request(options)
+    return request(req)
       .then((facebookResponse) => {
         if (!facebookResponse) {
           console.error('Empty Response')
           return dest ? 'Empty Response' : data
         }
 
-        const parsedResponse = JSON.parse(facebookResponse)
+        // Parse the response
+        const parsedResponse = parseFacebookResponse(facebookResponse, withCover)
         let responseData = parsedResponse.data
 
         // Increment the items count
@@ -106,12 +222,14 @@ function paginateResults(uri, qs = {}, dest, parsingFunc, maxItems) {
           responseData = responseData.map(parsingFunc)
         }
 
-        // If there is a dest, send the stringified results to it
-        if (dest) {
-          dest(JSON.stringify(responseData))
-        } else {
-          // Else concat the results
-          data = data.concat(responseData)
+        if (responseData) {
+          // If there is a dest, send the stringified results to it
+          if (dest) {
+            dest(JSON.stringify(responseData))
+          } else {
+            // Else concat the results
+            data = data.concat(responseData)
+          }
         }
 
         // Continue to the next results if needed
@@ -142,8 +260,8 @@ function getEvents(params = {}, dest) {
     throw new Error('No access token provided')
   }
 
-  const { token, batchSize, maxItems, parser } = params
-  const uri = `${facebookHost}${facebookAPIVersion}${getEventsURL}`
+  const { token, batchSize, withCover, maxItems, parser } = params
+  const uri = getEventsURL
   const queryParams = {
     access_token: token,
     limit: batchSize,
@@ -151,7 +269,7 @@ function getEvents(params = {}, dest) {
     fields: getEventsFields
   }
 
-  return paginateResults(uri, queryParams, dest, parser, maxItems)
+  return paginateResults(uri, queryParams, withCover, dest, parser, maxItems)
 }
 
 /**
@@ -168,14 +286,14 @@ function getLocations(params = {}, dest) {
     throw new Error('No access token provided')
   }
 
-  const { token, batchSize, maxItems, parser } = params
-  const uri = `${facebookHost}${facebookAPIVersion}${getTaggedPlacesURL}`
+  const { token, batchSize, withCover, maxItems, parser } = params
+  const uri = getTaggedPlacesURL
   const queryParams = {
     access_token: token,
     limit: batchSize
   }
 
-  return paginateResults(uri, queryParams, dest, parser, maxItems)
+  return paginateResults(uri, queryParams, withCover, dest, parser, maxItems)
 }
 
 module.exports = {

--- a/services/instagram.js
+++ b/services/instagram.js
@@ -15,7 +15,8 @@ function instagramDataParser(data, onlyWithLocation) {
   return data.reduce((results, feedRecord) => {
     const locationItem = {
       record_id: feedRecord.id,
-      timedate: new Date(parseInt(feedRecord.created_time, 10) * 1000)
+      timedate: new Date(parseInt(feedRecord.created_time, 10) * 1000),
+      images: feedRecord.images
     }
 
     if (feedRecord.location) {
@@ -92,11 +93,13 @@ function getUserPhotos(params = {}, dest) {
           photosData = instagramDataParser(photosData, onlyWithLocation)
         }
 
-        // Parse here
-        if (dest) {
-          dest(JSON.stringify(photosData))
-        } else {
-          data = data.concat(photosData)
+        if (photosData) {
+          // Parse here
+          if (dest) {
+            dest(JSON.stringify(photosData))
+          } else {
+            data = data.concat(photosData)
+          }
         }
 
         if ((!maxItems || count < maxItems) && instagramResponse.pagination.next_max_id) {

--- a/test/facebookTests.js
+++ b/test/facebookTests.js
@@ -91,6 +91,46 @@ describe('Facebook API', function() {
           })
         })
     })
+
+    it('Should return the covers with withCover option', function() {
+      const options = {
+        token: testToken,
+        withCover: true
+      }
+
+      return facebookAPI.getLocations(options)
+        .then((response) => {
+          response.should.be.an('array').and.have.lengthOf(15)
+          response.forEach((element) => {
+            element.should.have.all.keys('id', 'created_time', 'place', 'cover')
+            element.place.should.have.all.keys('id', 'location', 'name')
+          })
+        })
+    })
+
+    it('Should stream the results with covers with dest and withCover options', function() {
+      let chunksCount = 0
+      let fullResponseBody = []
+      const options = {
+        token: testToken,
+        batchSize: 3,
+        withCover: true
+      }
+      const dest = function dest(chunk) {
+        chunksCount += 1
+        fullResponseBody = fullResponseBody.concat(JSON.parse(chunk))
+      }
+
+      return facebookAPI.getLocations(options, dest)
+        .then(() => {
+          chunksCount.should.equal(5)
+          fullResponseBody.should.be.an('array').and.have.lengthOf(15)
+          fullResponseBody.forEach((element) => {
+            element.should.have.all.keys('id', 'created_time', 'place', 'cover')
+            element.place.should.have.all.keys('id', 'location', 'name')
+          })
+        })
+    })
   })
 
   describe('Events', function() {

--- a/test/instagramTests.js
+++ b/test/instagramTests.js
@@ -27,7 +27,7 @@ describe('instagram API', function() {
 
           response.should.be.an('array').with.lengthOf(20)
           response.forEach((item) => {
-            item.should.include.all.keys(['record_id', 'timedate', 'usersTagged'])
+            item.should.include.all.keys(['record_id', 'timedate', 'images', 'usersTagged'])
             if (item.info) {
               withLocation += 1
               item.should.include.all.keys(['latitude', 'longitude', 'info'])
@@ -61,7 +61,7 @@ describe('instagram API', function() {
           chunksCount.should.equal(5)
           fullResponseBody.should.be.an('array').with.lengthOf(12)
           fullResponseBody.forEach((item) => {
-            item.should.have.all.keys(['record_id', 'timedate', 'latitude', 'longitude', 'info', 'usersTagged'])
+            item.should.have.all.keys(['record_id', 'timedate', 'images', 'latitude', 'longitude', 'info', 'usersTagged'])
           })
           return true
         }).should.eventually.be.true


### PR DESCRIPTION
Resolves #4 

* **Instagram:** Retrieves by default the `images` property containing `low_resolution`, `thumbnail` and `standard_resolution`
* **Facebook:** Added the `withCover` option to make a Batch Request (see [here](https://developers.facebook.com/docs/graph-api/making-multiple-requests)) to retrieve the cover photo URL linked to the location page when available. Note that this functionality is currently disabled (temporary) by Facebook for inactive apps.